### PR TITLE
Upgrade to use prop-types so that it works with React 16+

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import PropTypes from 'prop-types';
+import React, {Component} from 'react';
 import {StyleSheet, StatusBar, Dimensions, View, Animated, Easing} from 'react-native';
 import NativeLinearGradient from 'react-native-linear-gradient';
 import rgb2hex from 'rgb2hex';

--- a/package.json
+++ b/package.json
@@ -25,9 +25,10 @@
   },
   "homepage": "https://github.com/heineiuo/react-native-animated-linear-gradient#readme",
   "dependencies": {
-    "react": "^15.4.2",
-    "react-native": "^0.42.0",
-    "react-native-linear-gradient": "^2.0.0",
+    "prop-types": "^15.6.0",
+    "react": "^16.0.0",
+    "react-native": "^0.49.5",
+    "react-native-linear-gradient": "^2.3.0",
     "rgb2hex": "^0.1.0"
   }
 }


### PR DESCRIPTION
React 16 no longer exports a PropTypes object and you should instead use the prop-types npm package.

In this PR I upgraded the dependencies and switched to use prop-types instead.